### PR TITLE
supply defaults for old games without configs

### DIFF
--- a/src/game/pieces.ts
+++ b/src/game/pieces.ts
@@ -5,6 +5,7 @@ import {
   randomFromArray,
   reportError,
 } from '@/game/common';
+import { DEFAULT_ZUG_CONFIG } from '@/game/zugzwang/config';
 
 type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
@@ -30,7 +31,8 @@ export const generatePiecePriority = ({
 }) => {
   const { piecePriorityOptions } = G.config;
   // Setting priority
-  let allowedPriorities = piecePriorityOptions;
+  let allowedPriorities =
+    piecePriorityOptions || DEFAULT_ZUG_CONFIG.piecePriorityOptions;
 
   if (priorityArray) {
     const priorityDifference = priorityArray.filter(

--- a/src/game/zugzwang/config.ts
+++ b/src/game/zugzwang/config.ts
@@ -16,6 +16,10 @@ export const DEFAULT_ZUG_CONFIG: ZugConfig = {
   piecePushRestrictions: false,
 };
 
+/**
+ * @deprecated
+ * use DEFAULT_ZUG_CONFIG.piecePriorityOptions directly instead
+ */
 export const PIECE_PRIORITIES_LIST = DEFAULT_ZUG_CONFIG.piecePriorityOptions;
 export const PIECE_PRIORITY_DUPLICATES =
   DEFAULT_ZUG_CONFIG.piecePriorityDuplicates;


### PR DESCRIPTION
```js
/app/src/game/pieces.ts:53
availablePriorities = allowedPriorities.filter(
^
TypeError: Cannot read properties of undefined (reading 'filter')
at generatePiecePriority (/app/src/game/pieces.ts:53:45)
at createPiece (/app/src/game/pieces.ts:107:28)
at applyPlace (/app/src/game/orders.ts:417:16)
at orderResolver (/app/src/game/orders.ts:264:11)
at onEnd (/app/src/game/Game.ts:198:27)
at recipe (/app/node_modules/boardgame.io/dist/cjs/server.js:42:28)
at produce (/app/node_modules/immer/src/core/immerClass.ts:94:14)
at /app/node_modules/boardgame.io/dist/cjs/server.js:41:22
at /app/node_modules/boardgame.io/dist/cjs/server.js:575:24
at /app/node_modules/boardgame.io/dist/cjs/server.js:510:19
```