### PR TITLE
"My turn" view

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -327,9 +327,50 @@ server.router.get(
       });
       match.score = state.G.score;
       match.turn = state.ctx.turn;
+      match.activePlayers = state.ctx.activePlayers;
     }
 
     ctx.body = { matches: matchList };
+  },
+);
+
+server.router.get(
+  '/games/:name/by-user/:username',
+  async (ctx: MatchesContext, next: (ctx: Koa.Context) => Promise<void>) => {
+    const { name: gameName, username } = ctx.params;
+    if (gameName !== 'zug') {
+      await next(ctx);
+      return;
+    }
+
+    const existingUser = await User.findOne({
+      where: { name: username },
+    });
+    if (!existingUser) {
+      return;
+    }
+
+    const matches = await existingUser.getMatches();
+    const matchesResponse = matches.map((match) => {
+      const { state, id, players } = match;
+      const { activePlayers } = state?.ctx || {};
+
+      // determine if it's their turn
+      let yourTurn = null;
+      if (activePlayers) {
+        const playerIndex = Object.values(players).findIndex(
+          (player) => player.name === username,
+        );
+        yourTurn = activePlayers[playerIndex] === 'planning';
+      }
+      return {
+        id,
+        activePlayers: state.ctx.activePlayers,
+        yourTurn,
+      };
+    });
+
+    ctx.body = { matches: matchesResponse };
   },
 );
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,6 +1,10 @@
-import type { LobbyAPI } from 'boardgame.io/dist/types/src/types';
+import type {
+  ActivePlayers,
+  LobbyAPI,
+} from 'boardgame.io/dist/types/src/types';
 
 export interface EnhancedMatch extends LobbyAPI.Match {
+  activePlayers: ActivePlayers | null;
   score: { 0: number; 1: number };
   turn: number;
 }

--- a/src/components/LobbyComponent.vue
+++ b/src/components/LobbyComponent.vue
@@ -22,15 +22,6 @@ const server = getServerURL();
 
 const saveMatchList = (matchList: LobbyAPI.MatchList) => {
   let matchData = matchList.matches as EnhancedMatch[];
-  if (!showOldMatches.value) {
-    const now = DateTime.now();
-    matchData = matchData.filter((m) => {
-      const updatedAt = DateTime.fromMillis(m.updatedAt);
-      const diffInDays = now.diff(updatedAt, 'days');
-      return diffInDays.days < 7;
-    });
-  }
-
   matches.value = matchData;
 };
 const lobbyClient = new LobbyClient({ server });
@@ -100,7 +91,10 @@ watch(matches, () => {
   const newRemainingMatches: EnhancedMatch[] = [];
 
   matches.value.forEach((match) => {
-    if (match.players.some((p) => p.name && p.name === store.zugUsername)) {
+    if (
+      match.players.some((p) => p.name && p.name === store.zugUsername) &&
+      newYourMatches.length < 6
+    ) {
       newYourMatches.push(match);
     } else if (match.players.some((p) => !p.name)) {
       newOpenMatches.push(match);
@@ -135,13 +129,13 @@ watch(matches, () => {
       />
       <h2>Matches</h2>
       <div class="center-align">
-        <span>Show all</span>
-        <InputSwitch
-          v-model="showOldMatches"
-          :onclick="fetchMatches"
-          style="flex-shrink: 0"
-          v-tooltip.top="'Matches older than 1 week are hidden by default'"
-        />
+        <!--        <span>Show all</span>-->
+        <!--        <InputSwitch-->
+        <!--          v-model="showOldMatches"-->
+        <!--          :onclick="fetchMatches"-->
+        <!--          style="flex-shrink: 0"-->
+        <!--          v-tooltip.top="'Matches older than 1 week are hidden by default'"-->
+        <!--        />-->
       </div>
     </div>
     <span>{{ joinStatus }}</span>

--- a/src/components/LobbyComponent.vue
+++ b/src/components/LobbyComponent.vue
@@ -76,6 +76,20 @@ const usersMatches = computed(() => {
     .map((match) => match.matchID);
 });
 
+const shouldHighlight = (match: EnhancedMatch) => {
+  const { activePlayers, players, gameover } = match;
+
+  let yourTurn = null;
+  if (activePlayers) {
+    const playerIndex = Object.values(players).findIndex(
+      (player) => player.name === store.zugUsername,
+    );
+    yourTurn = activePlayers[playerIndex] === 'planning';
+  }
+
+  return yourTurn && !gameover;
+};
+
 const yourMatches: Ref<EnhancedMatch[]> = ref([]);
 const openMatches: Ref<EnhancedMatch[]> = ref([]);
 const remainingMatches: Ref<EnhancedMatch[]> = ref([]);
@@ -137,7 +151,7 @@ watch(matches, () => {
         v-for="match in yourMatches"
         :key="match.matchID"
         :match="match"
-        :highlight="!match.gameover"
+        :highlight="shouldHighlight(match)"
         :handle-match-join="
           () => requestJoinMatch(match.matchID, undefined, navigateToMatch)
         "
@@ -150,7 +164,6 @@ watch(matches, () => {
         v-for="match in openMatches"
         :key="match.matchID"
         :match="match"
-        :highlight="usersMatches.includes(match.matchID)"
         :handle-match-join="
           () => requestJoinMatch(match.matchID, undefined, navigateToMatch)
         "
@@ -163,7 +176,6 @@ watch(matches, () => {
         v-for="match in remainingMatches"
         :key="match.matchID"
         :match="match"
-        :highlight="usersMatches.includes(match.matchID)"
         :handle-match-join="
           () => requestJoinMatch(match.matchID, undefined, navigateToMatch)
         "

--- a/src/components/LobbyComponent.vue
+++ b/src/components/LobbyComponent.vue
@@ -22,6 +22,9 @@ const server = getServerURL();
 
 const saveMatchList = (matchList: LobbyAPI.MatchList) => {
   let matchData = matchList.matches as EnhancedMatch[];
+  matchData.sort((a, b) => {
+    return a.updatedAt - b.updatedAt;
+  });
   matches.value = matchData;
 };
 const lobbyClient = new LobbyClient({ server });

--- a/src/components/LobbyComponent.vue
+++ b/src/components/LobbyComponent.vue
@@ -73,7 +73,7 @@ const usersMatches = computed(() => {
 const shouldHighlight = (match: EnhancedMatch) => {
   const { activePlayers, players, gameover } = match;
 
-  let yourTurn = null;
+  let yourTurn;
   if (activePlayers) {
     const playerIndex = Object.values(players).findIndex(
       (player) => player.name === store.zugUsername,

--- a/src/components/LobbyMatch.vue
+++ b/src/components/LobbyMatch.vue
@@ -70,8 +70,9 @@ const props = defineProps<LobbyMatchProps>();
 }
 .match {
   padding: 4px;
+  border-radius: 4px;
 }
 .highlight {
-  border: 2px solid orange;
+  box-shadow: 0 0 5px var(--color-theme-primary);
 }
 </style>

--- a/src/components/LobbyMatch.vue
+++ b/src/components/LobbyMatch.vue
@@ -73,6 +73,9 @@ const props = defineProps<LobbyMatchProps>();
   border-radius: 4px;
 }
 .highlight {
-  box-shadow: 0 0 5px var(--color-theme-primary);
+  box-shadow:
+    0 0 5px var(--color-theme-primary),
+    0 0 7px var(--tekhelet);
+  border: 1px solid var(--color-theme-primary);
 }
 </style>


### PR DESCRIPTION
Changes to the match page:
- Use the orange highlight when its your turn in a match
- Show your 6 most recent matches by default, regardless of how old
- remove "show all" toggle, show all by default in the same sections as before (open, other)