### PR TITLE
Use an auth token per match instead of main user token

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,10 +1,12 @@
+import type { MatchTokenPayload } from './types';
+
 const jwt = require('jsonwebtoken');
 
-export const encodeToken = (payload: { credentials: string }): string => {
+export const encodeToken = (payload: MatchTokenPayload): string => {
   return jwt.sign(payload, process.env.AUTH_SECRET);
 };
 
-export const decodeToken = (token: string) => {
+export const decodeToken = (token: string): MatchTokenPayload => {
   try {
     return jwt.verify(token, process.env.AUTH_SECRET);
   } catch (e) {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,8 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-import { type ZugUser } from '../src/utils/auth';
-
-export const encodeToken = (payload: ZugUser): string => {
+export const encodeToken = (payload: { credentials: string }): string => {
   return jwt.sign(payload, process.env.AUTH_SECRET);
 };
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -22,7 +22,7 @@ export const User = sequelize.define('User', {
     defaultValue: DataTypes.UUIDV4,
   },
   name: { type: DataTypes.STRING, allowNull: false, unique: true },
-  clerkId: { type: DataTypes.STRING, allowNull: false, unique: true },
+  clerkId: { type: DataTypes.STRING, unique: true },
   isGuest: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 });
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -22,7 +22,7 @@ export const User = sequelize.define('User', {
     defaultValue: DataTypes.UUIDV4,
   },
   name: { type: DataTypes.STRING, allowNull: false, unique: true },
-  clerkId: { type: DataTypes.STRING, unique: true },
+  clerkId: { type: DataTypes.STRING, unique: true, allowNull: true },
   isGuest: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 });
 
@@ -46,7 +46,7 @@ export const UserMatch = sequelize.define('UserMatch', {
 Match.belongsToMany(User, { through: UserMatch });
 User.belongsToMany(Match, { through: UserMatch });
 export const dbInitialized = sequelize
-  .sync()
+  .sync({ alter: true })
   .then(() => {
     console.log('All models synced!');
     return true;

--- a/server/guestUser.ts
+++ b/server/guestUser.ts
@@ -1,0 +1,11 @@
+import { randomUUID } from 'crypto';
+
+/**
+ * Generates a guest username using a character (e.g., '.') not allowed by Clerk.
+ * Example output: guest.abc123
+ */
+export function generateGuestUsername(): string {
+  // Use a short UUID (first 6 chars of a v4 UUID)
+  const shortId = randomUUID().slice(0, 6);
+  return `guest.${shortId}`;
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -133,7 +133,8 @@ const findOrRegisterClerkUser = async (clerkJwtPayload: JwtPayload) => {
   return user;
 };
 
-// Custom authentication handlers
+// (from docs) an optional function that returns player credentials to store in the game metadata and validate against.
+// If not specified, the uuid function will be used.
 const generateCredentials = async (ctx) => {
   // user sends clerk session token as auth header
   const authHeader = ctx.request.headers.authorization;
@@ -150,9 +151,12 @@ const generateCredentials = async (ctx) => {
   if (!user) {
     return false;
   }
-  return user.id;
+
+  // this will be the playerCredential passed to `join` api middleware
+  return randomUUID();
 };
 
+// TODO: authenticate using our own server-signed JWT, on a match-by-match basis
 const authenticateCredentials = async (credentials, playerMetadata) => {
   const start = Date.now();
   let tokenTime = 0;
@@ -262,6 +266,8 @@ server.router.post(
     await next(ctx);
 
     const body = ctx.body;
+    // body.playerCredentials is whatever generateCredentials returns
+    // TODO: add this credential to the userMatch when creating
     if (body.playerID) {
       const match = await Match.findByPk(matchID);
       const { players } = match;

--- a/server/main.ts
+++ b/server/main.ts
@@ -201,12 +201,11 @@ const generateCredentials = async (ctx) => {
   return randomUUID();
 };
 
-// TODO: authenticate using our own server-signed JWT, on a match-by-match basis
-const authenticateCredentials = async (credentials, playerMetadata) => {
+const authenticateCredentials = async (token, playerMetadata) => {
   try {
-    const token = await verifyToken(credentials, verifyOptions);
-    const user = await findUser(token.sub);
-    return user.id === playerMetadata.credentials;
+    const decodedToken = decodeToken(token);
+    const { credential } = decodedToken;
+    return credential === playerMetadata.credentials;
   } catch (error) {
     console.error(`Error: credentials did not authenticate:\n`, error, {
       playerMetadata,
@@ -301,8 +300,8 @@ server.router.post(
     await next(ctx);
 
     const body = ctx.body;
-    // body.playerCredentials is whatever generateCredentials returns
-    // TODO: add this credential to the userMatch when creating
+    const token = encodeToken({ credential: body.playerCredentials });
+    ctx.response.body.playerCredentials = token;
     if (body.playerID) {
       const match = await Match.findByPk(matchID);
       const { players } = match;

--- a/server/main.ts
+++ b/server/main.ts
@@ -12,6 +12,7 @@ import { createClerkClient } from '@clerk/backend';
 import { verifyToken } from '@clerk/backend';
 import { JwtPayload } from 'jsonwebtoken';
 import { messageDiscordUser } from './discordBot';
+import { generateGuestUsername } from './guestUser';
 
 // TODO: figure out which process needs this to be commonJS syntax
 const { Server, Origins } = require('boardgame.io/server');
@@ -92,15 +93,6 @@ Match.beforeUpsert(async (created) => {
   }
 });
 
-interface IBaseUser {
-  name: string;
-  credentials: string;
-}
-
-interface IUser extends IBaseUser {
-  discord?: any;
-}
-
 interface ZugToken extends ZugUser {
   iat: number; // 'instantiated at'
 }
@@ -167,7 +159,7 @@ const authenticateCredentials = async (credentials, playerMetadata) => {
   let userTime = 0;
   try {
     const token = await verifyToken(credentials, verifyOptions);
-    tokenTime = Date.now() - start
+    tokenTime = Date.now() - start;
     const user = await findUser(token.sub);
     userTime = Date.now() - start - tokenTime;
     return user.id === playerMetadata.credentials;
@@ -202,31 +194,55 @@ const frontEndAppBuildPath = path.resolve(__dirname, '../dist');
 server.app.use(serve(frontEndAppBuildPath));
 
 server.router.post(
-  '/api/login',
+  '/api/guest/login',
   koaBody(),
   async (ctx: { body?: any; request?: any }) => {
-    const { request } = ctx;
-    const { username } = request.body;
+    // const { username } = request.body;
+    let username: string;
+    let usernameUnique = false;
+    while (!usernameUnique) {
+      username = generateGuestUsername();
+      const existingGuestUser = await User.findOne({
+        where: { name: username, isGuest: true },
+      });
 
-    const existingUser: IBaseUser = await TempUser.findOne({
-      where: { name: username },
+      if (!existingGuestUser) {
+        usernameUnique = true;
+      }
+    }
+    const newGuestUser = await User.create({
+      name: username,
+      isGuest: true,
     });
 
-    let credentials: string = randomUUID();
-    if (existingUser) {
-      credentials = existingUser.credentials;
-    } else {
-      await TempUser.create({ name: username, credentials });
-    }
-
     const tokenPayload = {
-      ...request.body,
-      credentials,
+      credentials: newGuestUser.id,
     };
 
     ctx.body = {
       authToken: encodeToken(tokenPayload),
       userID: username,
+    };
+  },
+);
+
+server.router.post(
+  '/api/guest/check',
+  koaBody(),
+  async (ctx: { body?: any; request?: any }) => {
+    const { token } = ctx.request.body;
+    const decodedToken = decodeToken(token);
+
+    const existingGuestUser = await User.findOne({
+      where: { id: decodedToken.credentials, isGuest: true },
+    });
+
+    let resp = 'bad';
+    if (existingGuestUser) {
+      resp = existingGuestUser.name;
+    }
+    ctx.body = {
+      resp,
     };
   },
 );

--- a/server/types.ts
+++ b/server/types.ts
@@ -8,3 +8,7 @@ export interface EnhancedMatch extends LobbyAPI.Match {
   score: { 0: number; 1: number };
   turn: number;
 }
+
+export interface MatchTokenPayload {
+  credential: string;
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,11 +4,14 @@ import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/vue';
 import Toast from 'primevue/toast';
 import { BOARD_PIXEL_SIZE } from '@/constants';
 import Logo from '@/assets/logo.svg';
+import { useClerkUser } from '@/composables/useClerkUser';
 
 const squareSize = BOARD_PIXEL_SIZE + 'px';
 const root = document.querySelector(':root');
 // @ts-expect-error
 root.style.setProperty('--square-size', squareSize);
+// initialize clerk composable
+useClerkUser();
 </script>
 
 <template>

--- a/src/components/LobbyComponent.vue
+++ b/src/components/LobbyComponent.vue
@@ -57,16 +57,7 @@ const createMatch = async (
   await requestJoinMatch(createdMatch.matchID, setupData, navigateToMatch);
 };
 
-const { joinStatus, requestJoinMatch } = useMatch(lobbyClient);
-
-const navigateToMatch = (matchID: string) => {
-  router.push({
-    name: 'match',
-    params: {
-      matchID,
-    },
-  });
-};
+const { joinStatus, requestJoinMatch, navigateToMatch } = useMatch();
 
 const handleCustomClick = () => {
   router.push({

--- a/src/components/LobbyComponent.vue
+++ b/src/components/LobbyComponent.vue
@@ -4,7 +4,7 @@ import type { Ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { LobbyClient } from 'boardgame.io/client';
 import Button from 'primevue/button';
-import { useUser } from '@clerk/vue';
+import { useClerkUser } from '@/composables/useClerkUser';
 
 import LobbyMatch from '@/components/LobbyMatch.vue';
 import type { GameSetupData } from '@/game/Game';
@@ -20,7 +20,7 @@ import { type LobbyAPI } from 'boardgame.io';
 const matches: Ref<EnhancedMatch[]> = ref([]);
 const lastFetched = ref();
 const server = getServerURL();
-const { user } = useUser();
+const { clerkUsername } = useClerkUser();
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -80,7 +80,7 @@ const shouldHighlight = (match: EnhancedMatch) => {
   let yourTurn;
   if (activePlayers) {
     const playerIndex = Object.values(players).findIndex(
-      (player) => player.name === user.value?.username,
+      (player) => player.name === clerkUsername.value,
     );
     yourTurn = activePlayers[playerIndex] === 'planning';
   }
@@ -92,14 +92,14 @@ const yourMatches: Ref<EnhancedMatch[]> = ref([]);
 const openMatches: Ref<EnhancedMatch[]> = ref([]);
 const remainingMatches: Ref<EnhancedMatch[]> = ref([]);
 
-watch([matches, user], () => {
+watch([matches, clerkUsername], () => {
   const newYourMatches: EnhancedMatch[] = [];
   const newOpenMatches: EnhancedMatch[] = [];
   const newRemainingMatches: EnhancedMatch[] = [];
 
   matches.value.forEach((match) => {
     if (
-      match.players.some((p) => p.name && p.name === user.value?.username) &&
+      match.players.some((p) => p.name && p.name === clerkUsername.value) &&
       newYourMatches.length < 6
     ) {
       newYourMatches.push(match);

--- a/src/components/MatchConfiguration.vue
+++ b/src/components/MatchConfiguration.vue
@@ -19,7 +19,7 @@ import {
   type ZugConfig,
 } from '@/game/zugzwang/config';
 import { getServerURL } from '@/utils';
-import { useMatch } from '@/composables/useMatch';
+import { navigateToMatch } from '@/composables/useMatch';
 import type { GameSetupData } from '@/game/Game';
 
 // input: "1,2,3,4"
@@ -93,7 +93,6 @@ const ruleSet = computed<ZugConfig>(() => {
 const server = getServerURL();
 
 const lobbyClient = new LobbyClient({ server });
-const { navigateToMatch } = useMatch(lobbyClient);
 const createMatch = async () => {
   try {
     const setupData: GameSetupData = { config: ruleSet.value };

--- a/src/composables/useClerkUser.ts
+++ b/src/composables/useClerkUser.ts
@@ -7,20 +7,6 @@ const clerkUsername = ref('');
 export function useClerkUser() {
   const clerk = useClerk();
 
-  onMounted(() => {
-    if (!clerk.value) return;
-    clerk.value.addListener(async ({ session }) => {
-      const token = await session?.getToken();
-      if (token) {
-        clerkToken.value = token;
-      }
-    });
-    const username = clerk.value.session?.user.username;
-    if (username) {
-      clerkUsername.value = username;
-    }
-  });
-
   watch(
     clerk,
     (newClerk) => {

--- a/src/composables/useClerkUser.ts
+++ b/src/composables/useClerkUser.ts
@@ -1,0 +1,46 @@
+import { ref, watch, onMounted } from 'vue';
+import { useClerk } from '@clerk/vue';
+
+const clerkToken = ref('');
+const clerkUsername = ref('');
+
+export function useClerkUser() {
+  const clerk = useClerk();
+
+  onMounted(() => {
+    if (!clerk.value) return;
+    clerk.value.addListener(async ({ session }) => {
+      const token = await session?.getToken();
+      if (token) {
+        clerkToken.value = token;
+      }
+    });
+    const username = clerk.value.session?.user.username;
+    if (username) {
+      clerkUsername.value = username;
+    }
+  });
+
+  watch(
+    clerk,
+    (newClerk) => {
+      if (!newClerk) return;
+      newClerk.addListener(async ({ session }) => {
+        const token = await session?.getToken();
+        if (token) {
+          clerkToken.value = token;
+        }
+      });
+      const username = newClerk.session?.user.username;
+      if (username) {
+        clerkUsername.value = username;
+      }
+    },
+    { immediate: true },
+  );
+
+  return {
+    clerkToken,
+    clerkUsername,
+  };
+}

--- a/src/composables/useMatch.ts
+++ b/src/composables/useMatch.ts
@@ -48,7 +48,7 @@ export const useMatch = (matchID: string) => {
     navigateToMatch?: (matchID: string) => void,
   ) => {
     // TODO: guests won't have a clerk token
-    if (!clerkToken) {
+    if (!clerkToken.value) {
       joinStatus.value = 'failed';
       return;
     }

--- a/src/composables/useMatch.ts
+++ b/src/composables/useMatch.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue';
 import { type GameSetupData } from '@/game/Game';
 import type { LobbyClient } from 'boardgame.io/client';
 import router from '@/router';
-import { Clerk } from '@clerk/clerk-js';
+import { useClerkUser } from '@/composables/useClerkUser';
 
 const navigateToMatch = async (matchID: string) => {
   try {
@@ -17,31 +17,26 @@ const navigateToMatch = async (matchID: string) => {
   }
 };
 
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
-
 export const useMatch = (lobbyClient: LobbyClient) => {
+  const { clerkToken, clerkUsername } = useClerkUser();
   const joinStatus = ref('');
   const requestJoinMatch = async (
     matchID: string,
     setupData?: GameSetupData,
     navigateToMatch?: (matchID: string) => void,
   ) => {
-    const clerk = new Clerk(clerkPubKey);
-    await clerk.load();
-    if (!clerk.session) {
-      console.error('no clerk session');
+    if (!clerkToken) {
       joinStatus.value = 'failed';
       return;
     }
-    const token = await clerk.session.getToken();
     joinStatus.value = 'loading';
     const authHeader = setupData?.empty ? 'open' : 'error';
     try {
       const resp = await lobbyClient.joinMatch(
         'zug',
         matchID,
-        { playerName: clerk.session.user.username || 'error' },
-        { headers: { authorization: token || authHeader } },
+        { playerName: clerkUsername.value || 'error' },
+        { headers: { authorization: clerkToken.value || authHeader } },
       );
       if (resp.playerID) {
         joinStatus.value = 'success';

--- a/src/composables/useMatch.ts
+++ b/src/composables/useMatch.ts
@@ -38,9 +38,9 @@ const getMatchData = (matchID: string): LocalStorageMatch | null => {
 const server = getServerURL();
 const lobbyClient = new LobbyClient({ server });
 
-export const useMatch = (matchID: string) => {
+export const useMatch = (matchID?: string) => {
   const { clerkToken, clerkUsername } = useClerkUser();
-  const localMatchData = getMatchData(matchID);
+  const localMatchData = matchID ? getMatchData(matchID) : null;
   const joinStatus = ref('');
   const requestJoinMatch = async (
     matchID: string,

--- a/src/composables/useMatch.ts
+++ b/src/composables/useMatch.ts
@@ -6,7 +6,7 @@ import router from '@/router';
 import { useClerkUser } from '@/composables/useClerkUser';
 import { getServerURL } from '@/utils';
 
-const navigateToMatch = async (matchID: string) => {
+export const navigateToMatch = async (matchID: string) => {
   try {
     return await router.push({
       name: 'match',

--- a/src/composables/useMatch.ts
+++ b/src/composables/useMatch.ts
@@ -1,8 +1,10 @@
 import { ref } from 'vue';
 import { type GameSetupData } from '@/game/Game';
-import type { LobbyClient } from 'boardgame.io/client';
+import { LobbyClient } from 'boardgame.io/client';
+
 import router from '@/router';
 import { useClerkUser } from '@/composables/useClerkUser';
+import { getServerURL } from '@/utils';
 
 const navigateToMatch = async (matchID: string) => {
   try {
@@ -17,14 +19,35 @@ const navigateToMatch = async (matchID: string) => {
   }
 };
 
-export const useMatch = (lobbyClient: LobbyClient) => {
+export interface LocalStorageMatch {
+  token: string;
+}
+
+const setMatchData = (matchID: string, payload: LocalStorageMatch) => {
+  localStorage.setItem(matchID, JSON.stringify(payload));
+};
+
+const getMatchData = (matchID: string): LocalStorageMatch | null => {
+  const matchData = localStorage.getItem(matchID);
+  if (matchData) {
+    return JSON.parse(matchData);
+  }
+  return null;
+};
+
+const server = getServerURL();
+const lobbyClient = new LobbyClient({ server });
+
+export const useMatch = (matchID: string) => {
   const { clerkToken, clerkUsername } = useClerkUser();
+  const localMatchData = getMatchData(matchID);
   const joinStatus = ref('');
   const requestJoinMatch = async (
     matchID: string,
     setupData?: GameSetupData,
     navigateToMatch?: (matchID: string) => void,
   ) => {
+    // TODO: guests won't have a clerk token
     if (!clerkToken) {
       joinStatus.value = 'failed';
       return;
@@ -38,8 +61,10 @@ export const useMatch = (lobbyClient: LobbyClient) => {
         { playerName: clerkUsername.value || 'error' },
         { headers: { authorization: clerkToken.value || authHeader } },
       );
-      if (resp.playerID) {
+      const { playerCredentials } = resp;
+      if (playerCredentials) {
         joinStatus.value = 'success';
+        setMatchData(matchID, { token: playerCredentials });
         if (navigateToMatch) {
           navigateToMatch(matchID);
         }
@@ -53,5 +78,5 @@ export const useMatch = (lobbyClient: LobbyClient) => {
     }
   };
 
-  return { joinStatus, requestJoinMatch, navigateToMatch };
+  return { joinStatus, requestJoinMatch, navigateToMatch, localMatchData };
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -39,6 +39,11 @@ const router = createRouter({
       name: 'login',
       component: () => import('../views/DiscordLogin.vue'),
     },
+    {
+      path: '/guest',
+      name: 'guest-test',
+      component: () => import('../views/GuestTestView.vue'),
+    },
   ],
 });
 

--- a/src/views/GuestTestView.vue
+++ b/src/views/GuestTestView.vue
@@ -69,14 +69,12 @@ async function checkGuest() {
   padding: 2rem;
   border: 1px solid #ccc;
   border-radius: 8px;
-  background: #fafafa;
 }
 button {
   margin-right: 1rem;
   margin-bottom: 1rem;
 }
 pre {
-  background: #eee;
   padding: 1rem;
   border-radius: 4px;
   overflow-x: auto;

--- a/src/views/GuestTestView.vue
+++ b/src/views/GuestTestView.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="guest-test-view">
+    <h1>Guest User API Test</h1>
+    <button @click="loginGuest">Login as Guest</button>
+    <button @click="checkGuest" :disabled="!authToken">
+      Check Guest Token
+    </button>
+    <div v-if="result">
+      <h2>Result</h2>
+      <pre>{{ result }}</pre>
+    </div>
+    <div v-if="authToken">
+      <h3>Auth Token</h3>
+      <pre>{{ authToken }}</pre>
+    </div>
+    <div v-if="userID">
+      <h3>Guest Username</h3>
+      <pre>{{ userID }}</pre>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const authToken = ref('');
+const userID = ref('');
+const result = ref('');
+
+async function loginGuest() {
+  result.value = '';
+  authToken.value = '';
+  userID.value = '';
+  try {
+    const res = await fetch('/api/guest/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const data = await res.json();
+    authToken.value = data.authToken;
+    userID.value = data.userID;
+    result.value = JSON.stringify(data, null, 2);
+  } catch (e) {
+    result.value = 'Error: ' + e;
+  }
+}
+
+async function checkGuest() {
+  if (!authToken.value) return;
+  try {
+    const res = await fetch('/api/guest/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: authToken.value }),
+    });
+    const data = await res.json();
+    result.value = JSON.stringify(data, null, 2);
+  } catch (e) {
+    result.value = 'Error: ' + e;
+  }
+}
+</script>
+
+<style scoped>
+.guest-test-view {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+}
+button {
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+}
+pre {
+  background: #eee;
+  padding: 1rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+</style>

--- a/src/views/MatchView.vue
+++ b/src/views/MatchView.vue
@@ -112,7 +112,7 @@ const { joinStatus, requestJoinMatch, localMatchData } = useMatch(matchID);
 const matchClientOne = new SimulChessClient(
   playerID.value === null ? playerID.value : String(playerID.value),
   matchID,
-  localMatchData?.token,
+  localMatchData?.token ?? '',
 );
 
 watch(playerID, () => {

--- a/src/views/MatchView.vue
+++ b/src/views/MatchView.vue
@@ -31,7 +31,6 @@ import {
 } from '@/utils/titleAnimation';
 import MatchInvite from '@/components/MatchInvite.vue';
 import { useMatch } from '@/composables/useMatch';
-import { LobbyClient } from 'boardgame.io/client';
 import { getServerURL } from '@/utils';
 import ButtonStepper from '@/components/ButtonStepper.vue';
 import { useMatchLink } from '@/composables/useMatchLink';
@@ -41,17 +40,9 @@ import { useClerkUser } from '@/composables/useClerkUser';
 // TODO: make matchToken
 const { clerkToken, clerkUsername } = useClerkUser();
 
-watch(clerkToken, () => {
-  matchClientOne.client.updateCredentials(clerkToken.value);
-});
-
 const windowHasFocus = useWindowFocus();
 const toast = useToast();
 const { handleError } = useErrorHandler();
-
-const server = getServerURL();
-const lobbyClient = new LobbyClient({ server });
-const { joinStatus, requestJoinMatch } = useMatch(lobbyClient);
 
 watch(windowHasFocus, (newFocus) => {
   if (newFocus) {
@@ -113,6 +104,7 @@ if (typeof route.params.matchID === 'string') {
   matchID = route.params.matchID[0];
 }
 const { copyLink } = useMatchLink(matchID);
+const { joinStatus, requestJoinMatch, localMatchData } = useMatch(matchID);
 
 /**
  * TODO: allow side-by-side clients in testing matches or while spectating (playerID=null)
@@ -120,6 +112,7 @@ const { copyLink } = useMatchLink(matchID);
 const matchClientOne = new SimulChessClient(
   playerID.value === null ? playerID.value : String(playerID.value),
   matchID,
+  localMatchData?.token,
 );
 
 watch(playerID, () => {
@@ -257,6 +250,8 @@ const canJoin = computed(() => {
   );
   return playerID.value === null && !gameLastTurn.value && openPlayerSlot;
 });
+
+// TODO: this needs to set the credential in the client
 const handleJoin = () => {
   requestJoinMatch(matchID)
     .then((resp) => {

--- a/src/views/MatchView.vue
+++ b/src/views/MatchView.vue
@@ -251,7 +251,6 @@ const canJoin = computed(() => {
   return playerID.value === null && !gameLastTurn.value && openPlayerSlot;
 });
 
-// TODO: this needs to set the credential in the client
 const handleJoin = () => {
   requestJoinMatch(matchID)
     .then((resp) => {

--- a/src/views/MatchView.vue
+++ b/src/views/MatchView.vue
@@ -36,33 +36,14 @@ import { getServerURL } from '@/utils';
 import ButtonStepper from '@/components/ButtonStepper.vue';
 import { useMatchLink } from '@/composables/useMatchLink';
 import { BoardDisplay } from '@/components/BoardDisplay';
-import { useClerk } from '@clerk/vue';
+import { useClerkUser } from '@/composables/useClerkUser';
 
 // TODO: make matchToken
-const clerkToken = ref('');
-const clerkUsername = ref('');
+const { clerkToken, clerkUsername } = useClerkUser();
+
 watch(clerkToken, () => {
   matchClientOne.client.updateCredentials(clerkToken.value);
 });
-
-const clerk = useClerk();
-watch(
-  clerk,
-  (newClerk) => {
-    if (!newClerk) return;
-    newClerk.addListener(async ({ session }) => {
-      const token = await session?.getToken();
-      if (token) {
-        clerkToken.value = token;
-      }
-    });
-    const username = newClerk.session?.user.username;
-    if (username) {
-      clerkUsername.value = username;
-    }
-  },
-  { immediate: true },
-);
 
 const windowHasFocus = useWindowFocus();
 const toast = useToast();
@@ -396,7 +377,7 @@ getNotificationSound(store.zugUsername).then((notificationSound) => {
 </script>
 
 <template>
-  <main v-if="!clerk">Loading...</main>
+  <main v-if="!clerkToken">Loading...</main>
   <main v-else>
     <div v-if="canJoin">
       <p v-if="!clerkToken">Sign in to join this game</p>


### PR DESCRIPTION
Authenticating against matches using a match-specific token.
This should reduce laggy interactions because Clerk refreshes constantly
It also lays the groundwork for guest users to play, by removing Clerk as the per-match auth method.